### PR TITLE
Fixes the space with the version matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 script: asdf plugin-test minikube .
 before_script:
-  - git clone https://github.com/asdf-vm/asdf.git
+  - git clone --branch v0.5.0 https://github.com/asdf-vm/asdf.git
   - . asdf/asdf.sh
 os:
   - linux

--- a/bin/list-all
+++ b/bin/list-all
@@ -14,5 +14,5 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\": \".{1,15}\"," | sed 's/tag_name\": \"v//;s/\",//' | sort_versions)
+versions=$(eval $cmd | grep -oE "tag_name\":\s?\".{1,15}\"," | sed -E 's/tag_name\":\s?\"v([0-9\.]+)\",/\1/'| sort_versions)
 echo $versions


### PR DESCRIPTION
* I'm unsure if this is an api change, or maybe a difference in the way
curl works between OS's, however the initial grep wasn't working due to
a space that didn't exist.
* I've made the space optional, and adjusted the sed to work
appropriately.

Signed-off-by: John T Skarbek <jtslear@gmail.com>